### PR TITLE
Demonstrate fix by updating to PR version of React

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,8 +11,8 @@
     "jest": "^29.4.3",
     "jest-environment-jsdom": "^29.4.3",
     "parcel": "^2.8.3",
-    "react": "^18.3.0-next-b72ed698f-20230303",
-    "react-dom": "^18.3.0-next-b72ed698f-20230303",
+    "react": "https://react-builds.vercel.app/api/prs/26317/packages/react",
+    "react-dom": "https://react-builds.vercel.app/api/prs/26317/packages/react-dom",
     "suspense": "^0.0.12"
   }
 }


### PR DESCRIPTION
Not for merge.

Updated package.json to point `react` and `react-dom` to PR that includes a bugfix: https://github.com/facebook/react/pull/26317

Now when you run the tests, the second test no longer hangs.